### PR TITLE
Escape \text

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -29,7 +29,7 @@ class Main
       value:
         "**`~year <1-4, masters, alumni>`** - add your current academic status to your profile.\n"\
         "**`~purge <2-99>`** - remove the last `n` messages in channel (**admin only**)\n"\
-        "**`~latex <latex command>`** - write latex in Mathmode to get a rendered image.\n"\
+        "**`~equation <latex command>`** - returns an image of a latex equation.\n"\
         "**`~help`** - return the help menu\n"\
         "\n\u200B"
     )
@@ -50,7 +50,7 @@ class Main
   end
 
   # run when command is ~latex
-  bot.command(:latex) do |event|
+  bot.command(:equation) do |event|
     begin
       # Combine every word after 'latex' for multi word arguments (eg \frac{23 a}{32} )
       args = event.message.content.split(' ').drop(1).join(' ')

--- a/services/latex_service.rb
+++ b/services/latex_service.rb
@@ -44,6 +44,14 @@ class LatexService
 
   # sanitizes the message by putting a backslash in front of some chars
   def self.sanitize(message)
+    # these are restricted commands
+    # \text because it can let people put text in math mode and bog down it system
+    # \text is replaced with \backslash text
+    res_commands = [['\\text', '\\backslash text~']]
+    res_commands.each do |res, replace|
+      message = message.gsub(res, replace)
+    end
+
     # each symbol is a different one that could cause problems
     # $ is to enter/exit math mode which would cause compilation problems
     # \\ is obvious


### PR DESCRIPTION
it escapes \text because it lets text and normal latex commands which can slow down the system. also changed ~latex to ~equation to reinforce that it supposed to an equation.