### PR TITLE
made an oopsie that would escape commands that arent troublesome

### DIFF
--- a/services/latex_service.rb
+++ b/services/latex_service.rb
@@ -45,9 +45,10 @@ class LatexService
   # sanitizes the message by putting a backslash in front of some chars
   def self.sanitize(message)
     # these are restricted commands
+    # commands need to end with a { or it will match all commands that start with it
     # \text because it can let people put text in math mode and bog down it system
     # \text is replaced with \backslash text
-    res_commands = [['\\text', '\\backslash text~']]
+    res_commands = [['\\text{', '\\backslash text~{']]
     res_commands.each do |res, replace|
       message = message.gsub(res, replace)
     end


### PR DESCRIPTION
i forgot a { on the end of \\text. without it, it would match anything that started with \text such as \textbackslash or \textasciitilde. 

for escaping commands, this is a simple way of making sure it matches. though it might be possible to make it match subscript and super script but as \text isn't a formula command, I am not that worried about it.