### PR TITLE
Prevent bot from sending an integer when using purge command

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -121,6 +121,7 @@ class Main
     end
 
     event.channel.prune(num_messages)
+    return
   end
 
   bot.command(:year) do |event|


### PR DESCRIPTION
The bot currently sends an integer after using the purge command. 

![image](https://user-images.githubusercontent.com/1490434/80640981-30350380-8a32-11ea-8bd5-be5f748f78a3.png)

This is because the method returned the value of the last line in the method: `event.channel.prune(num_messages)`. This PR simply adds a `return` at the end so that the method returns nothing.