### PR TITLE
Change config lang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 secrets.json
+config.hcl
 images/
 .bundle/
 vendor/
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-secrets.json
-config.hcl
+config.conf
 images/
 .bundle/
 vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem "discordrb"
-gem "json"
 gem "hcl-checker"
 gem "fuzzy-string-match"
 gem "mathematical"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem "discordrb"
-gem "hcl-checker"
+gem "hocon"
 gem "fuzzy-string-match"
 gem "mathematical"
 gem "mini_magick"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "discordrb"
 gem "json"
+gem "hcl-checker"
 gem "fuzzy-string-match"
 gem "mathematical"
 gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     ffi (1.9.25)
     fuzzy-string-match (1.0.1)
       RubyInline (>= 3.8.6)
+    hcl-checker (1.5.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.3)
@@ -55,6 +56,7 @@ PLATFORMS
 DEPENDENCIES
   discordrb
   fuzzy-string-match
+  hcl-checker
   json
   mathematical
   mini_magick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,12 +19,11 @@ GEM
     ffi (1.9.25)
     fuzzy-string-match (1.0.1)
       RubyInline (>= 3.8.6)
-    hcl-checker (1.5.0)
+    hocon (1.3.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
-    json (2.0.2)
     mathematical (1.6.13)
       ruby-enum (~> 0.4)
     mime-types (3.1)
@@ -56,8 +55,7 @@ PLATFORMS
 DEPENDENCIES
   discordrb
   fuzzy-string-match
-  hcl-checker
-  json
+  hocon
   mathematical
   mini_magick
 

--- a/config.example.conf
+++ b/config.example.conf
@@ -9,10 +9,9 @@ urls {
 }
 
 features {
-  /*
-  each feature can be turned on or off
-  with true or false
-  */
+  // each feature can be turned on or off
+  // with true or false
+
   equation=true
 
 }

--- a/config.example.hcl
+++ b/config.example.hcl
@@ -1,0 +1,18 @@
+mc_address_url = ""
+api_token = ""
+api_client_id = ""
+bot_user_id = 468629052643868673
+
+urls {
+  image_directory_url = ""
+  mc_address_url = ""
+}
+
+features {
+  /*
+  each feature can be turned on or off
+  with true or false
+  */
+  equation=true
+
+}

--- a/main.rb
+++ b/main.rb
@@ -1,17 +1,18 @@
 require 'discordrb'
 require 'pry'
-require 'json'
+require 'hcl/checker'
 require 'fuzzystringmatch'
 require_relative 'services/discord_message_sender'
 require_relative 'services/building_service'
 require_relative 'services/latex_service'
 
 class Main
-  SECRETS = JSON.parse(File.read('secrets.json'))
-  IMAGE_DIRECTORY_URL = SECRETS["image_directory_url"]
+  CONFIG = HCL::Checker.parse(File.read('config.hcl'))
+  IMAGE_DIRECTORY_URL = CONFIG["urls"]["image_directory_url"]
   LATEX_DIRECTORY_RELATIVE_PATH = "tmp"
   # comment out the BOT_USER_ID when dev
   BOT_USER_ID = 468629052643868673
+  BOT_USER_ID = CONFIG["bot_user_id"]
   EXCLUDE_ROLES = [
     "Bot",
     "Admin",
@@ -23,8 +24,8 @@ class Main
   ]
   
   bot = Discordrb::Commands::CommandBot.new(
-    token: SECRETS["api_token"],
-    client_id: SECRETS["api_client_id"],
+    token: CONFIG["api_token"],
+    client_id: CONFIG["api_client_id"],
     prefix: '~',
   )
 

--- a/main.rb
+++ b/main.rb
@@ -1,17 +1,15 @@
 require 'discordrb'
 require 'pry'
-require 'hcl/checker'
+require 'hocon'
 require 'fuzzystringmatch'
 require_relative 'services/discord_message_sender'
 require_relative 'services/building_service'
 require_relative 'services/latex_service'
 
 class Main
-  CONFIG = HCL::Checker.parse(File.read('config.hcl'))
+  CONFIG = Hocon.load("config.conf")
   IMAGE_DIRECTORY_URL = CONFIG["urls"]["image_directory_url"]
   LATEX_DIRECTORY_RELATIVE_PATH = "tmp"
-  # comment out the BOT_USER_ID when dev
-  BOT_USER_ID = 468629052643868673
   BOT_USER_ID = CONFIG["bot_user_id"]
   EXCLUDE_ROLES = [
     "Bot",

--- a/secrets-example.json
+++ b/secrets-example.json
@@ -1,5 +1,0 @@
-{
-  "image_directory_url": "http://google.ca/images",
-  "api_token": "token",
-  "api_client_id": "client"
-}

--- a/services/discord_message_sender.rb
+++ b/services/discord_message_sender.rb
@@ -1,7 +1,7 @@
 class DiscordMessageSender
-  secrets = JSON.parse(File.read('secrets.json'))
+  CONFIG = Hocon.load("config.conf")
   SIDE_COLOR = "005696"
-  IMAGE_DIRECTORY_URL = secrets["image_directory_url"]
+  IMAGE_DIRECTORY_URL = CONFIG["urls"]["image_directory_url"]
   UWINDSOR_THUMBNAIL = Discordrb::Webhooks::EmbedThumbnail.new(url: "#{IMAGE_DIRECTORY_URL}/uw_logo.png")
 
   def self.send_embedded(


### PR DESCRIPTION
this is step 1 in refactoring and expanding the bot
the other steps are
- fixing bad logic
- using discord containers to spread out our code and make it more readable
- featurization, splitting each feature into its own container and using config settings to turn the features on or off 

### What are you trying to accomplish?
replacing json with ~~hcl~~ HOCON as a config lang

~~hcl(Hashicorp configuration lang) adds better things like more intuative syntax, comments, and ease of use~~
same stuff about HOCON, its just more fleshed out and has better support for ruby

### How are you accomplishing it?

by copying `secrets-example.json` over to ~~`config.example.hcl`~~ `config.example.conf` and moving over its logic over to a more organized and layed out fashion






### Is there anything reviewers should know?

~~the current parsers for hcl in ruby arent amazing, they work but could be greatly improved.~~
~~this feature may not be best in the long run because it might not be maintained and we would either need to~~
~~1. abandon it and go back to another lang~~
~~or~~
~~2. write our own, which is certainly doable with YACC~~

none of that is true anymore because HOCON has a great parser and lang support for ruby. no issues anymore


- [x] Is it safe to rollback this change if anything goes wrong?
