### PR TITLE
Prompt

### DIFF
--- a/config.example.conf
+++ b/config.example.conf
@@ -1,15 +1,26 @@
 api_token = ""
 api_client_id = ""
-prefix = "~"
 bot_user_id = 8
+
+// command prefix
+prefix = "~"
+
+// sets the debug messages on or off with the API
 debug = false
 
+// anything relating to the community prompt
 prompt {
-       channel = "comunity-prompts"
+       channel = "community-prompts"
+
+       // top and bottom text to the prompt message
+       // the prompt text given will be inbetween those
+       // if you want to reference a channel or user, you need to follow
+       // the proper way to reference things with their encoded IDs
        top_text =""
        bottom_text = ""
 }
 
+// important urls
 urls {
   image_directory_url = ""
   mc_address_url = ""

--- a/config.example.conf
+++ b/config.example.conf
@@ -3,7 +3,12 @@ api_client_id = ""
 prefix = "~"
 bot_user_id = 8
 debug = false
-prompt_channel = ""
+
+prompt {
+       channel = "comunity-prompts"
+       top_text =""
+       bottom_text = ""
+}
 
 urls {
   image_directory_url = ""

--- a/config.example.conf
+++ b/config.example.conf
@@ -3,6 +3,7 @@ api_client_id = ""
 prefix = "~"
 bot_user_id = 8
 debug = false
+prompt_channel = ""
 
 urls {
   image_directory_url = ""
@@ -19,5 +20,6 @@ features {
   whereis=true
   eventRoles=true
   say=true
+  prompt=true
 
 }

--- a/config.rb
+++ b/config.rb
@@ -10,7 +10,7 @@ module Config
   API_TOKEN = CONFIG["api_token"]
   API_CLIENT_ID = CONFIG["api_client_id"]
   PREFIX = CONFIG["prefix"]
-  PROMPT_CHANNEL = CONFIG["prompt_channel"]
+  PROMPT = CONFIG["prompt"]
   IMAGE_DIRECTORY_URL = CONFIG["urls"]["image_directory_url"]
   LATEX_DIRECTORY_RELATIVE_PATH = "tmp"
   BOT_USER_ID = CONFIG["bot_user_id"]
@@ -25,5 +25,5 @@ module Config
     "CSS Board Head",
     "CSS Board Member",
   ]
- 
+
 end

--- a/config.rb
+++ b/config.rb
@@ -10,6 +10,7 @@ module Config
   API_TOKEN = CONFIG["api_token"]
   API_CLIENT_ID = CONFIG["api_client_id"]
   PREFIX = CONFIG["prefix"]
+  PROMPT_CHANNEL = CONFIG["prompt_channel"]
   IMAGE_DIRECTORY_URL = CONFIG["urls"]["image_directory_url"]
   LATEX_DIRECTORY_RELATIVE_PATH = "tmp"
   BOT_USER_ID = CONFIG["bot_user_id"]

--- a/main.rb
+++ b/main.rb
@@ -61,17 +61,27 @@ class Main
   bot.command(:prompt) do |event|
     return if CommandSentAsDirectMessageToBot.command_sent_as_direct_message_to_bot?(event)
 
-    # split 2 times and get the second split
-    # this gets the text after the command
-    text = event.message.content.split(' ', 2)[1]
+    begin
+      # split 2 times and get the second split
+      # this gets the text after the command
+      text = event.message.content.split(' ', 2)[1]
 
-    # check if the user has an important role
-    if UtilityService.important_role?(event.author)
-      prompt_channel = event.bot.find_channel(Config::PROMPT_CHANNEL).first
+      puts Config::PROMPT
 
-      DiscordMessageSender.send(prompt_channel, text)
+      # check if the user has an important role
+      if UtilityService.important_role?(event.author)
+        prompt_channel = event.bot.find_channel(Config::PROMPT["channel"]).first
+
+        puts Config::PROMPT["channel"]
+        puts prompt_channel
+
+        prompt_text = Config::PROMPT["top_text"] + text + Config::PROMPT["bottom_text"]
+
+        DiscordMessageSender.send(prompt_channel, prompt_text)
+      end
+    rescue Exception
+      ReturnError.return_error(event.channel, "Couldn't say message")
     end
-
   end
 
   # say featurization

--- a/main.rb
+++ b/main.rb
@@ -14,6 +14,7 @@ require_relative 'modules/equation'
 require_relative 'modules/year'
 require_relative 'modules/where_is'
 require_relative 'modules/say'
+require_relative 'modules/prompt'
 
 class Main
   # startup sequence
@@ -58,32 +59,10 @@ class Main
     )
   end
 
-  bot.command(:prompt) do |event|
-    return if CommandSentAsDirectMessageToBot.command_sent_as_direct_message_to_bot?(event)
-
-    begin
-      # split 2 times and get the second split
-      # this gets the text after the command
-      text = event.message.content.split(' ', 2)[1]
-
-      puts Config::PROMPT
-
-      # check if the user has an important role
-      if UtilityService.important_role?(event.author)
-        prompt_channel = event.bot.find_channel(Config::PROMPT["channel"]).first
-
-        puts Config::PROMPT["channel"]
-        puts prompt_channel
-
-        prompt_text = Config::PROMPT["top_text"] + text + Config::PROMPT["bottom_text"]
-
-        DiscordMessageSender.send(prompt_channel, prompt_text)
-      end
-    rescue Exception
-      ReturnError.return_error(event.channel, "Couldn't say message")
-    end
+  if Config::FEATURES["prompt"]
+    bot.include! Prompt
   end
-
+  
   # say featurization
   # run when command is ~say
   if Config::FEATURES["say"]

--- a/main.rb
+++ b/main.rb
@@ -58,6 +58,22 @@ class Main
     )
   end
 
+  bot.command(:prompt) do |event|
+    return if CommandSentAsDirectMessageToBot.command_sent_as_direct_message_to_bot?(event)
+
+    # split 2 times and get the second split
+    # this gets the text after the command
+    text = event.message.content.split(' ', 2)[1]
+
+    # check if the user has an important role
+    if UtilityService.important_role?(event.author)
+      prompt_channel = event.bot.find_channel(Config::PROMPT_CHANNEL).first
+
+      DiscordMessageSender.send(prompt_channel, text)
+    end
+
+  end
+
   # say featurization
   # run when command is ~say
   if Config::FEATURES["say"]

--- a/modules/prompt.rb
+++ b/modules/prompt.rb
@@ -1,0 +1,32 @@
+require 'discordrb'
+
+require_relative '../services/discord_message_sender'
+require_relative '../services/utility_service'
+require_relative '../services/return_error'
+require_relative '../services/command_direct_to_bot'
+
+module Prompt
+  extend Discordrb::Commands::CommandContainer
+
+  command(:prompt) do |event|
+    return if CommandSentAsDirectMessageToBot.command_sent_as_direct_message_to_bot?(event)
+
+    begin
+      # split 2 times and get the second split
+      # this gets the text after the command
+      text = event.message.content.split(' ', 2)[1]
+
+
+      # check if the user has an important role
+      if UtilityService.important_role?(event.author)
+        prompt_channel = event.bot.find_channel(Config::PROMPT["channel"]).first
+
+        prompt_text = Config::PROMPT["top_text"] + text + Config::PROMPT["bottom_text"]
+
+        DiscordMessageSender.send(prompt_channel, prompt_text)
+      end
+    rescue Exception
+      ReturnError.return_error(event.channel, "Couldn't say message")
+    end
+  end
+end

--- a/modules/say.rb
+++ b/modules/say.rb
@@ -28,7 +28,7 @@ module Say
         raise StandardError.new "Message wasnt formatted correctly or user didnt have perms"
       end
     rescue Exception
-        ReturnError.return_error(event.channel, "Couldn't say message")
+      ReturnError.return_error(event.channel, "Couldn't say message")
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
add a `~prompt` command that posts text in a specific community prompt channel

### How are you accomplishing it?
adding another module which checks if the user has an important role

if it does then it gets a channel object of a named channel. the name is kept in a config file.

once it does that, it combines the text given with the text in the config. and then sends it out to the channel.

not very complicated.

### Is there anything reviewers should know?
yes, to reference other channels(like `#general`) or reference people or roles(like `@ryan prairie`) in the config text, you need to put the encoded values in the config. this is because the bot will send the plain text otherwise which doesnt reference or ping anything. 
you also have to put new lines you want.

its just another thing to do in the config when you put it together. I decided not to prefill it in the config because it is HIGHLY server specific and so would lead to issues. If we want a more strict version, i will implement it.


- [x] Is it safe to rollback this change if anything goes wrong?
