### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# ruby version 2.7.2 using debian buster as base
+# using ubuntu 21.04 as a base and building from there
 FROM ubuntu:21.04
-#FROM ruby:2.7.2-buster
 
 # copy everything into home
 COPY . .
@@ -10,11 +9,14 @@ RUN chmod 1777 /tmp
 
 # update repository info cache
 RUN apt-get update -yqq && \
-apt-get install -yqq \
-apt-utils ca-certificates
+apt-get install -yqq apt-utils ca-certificates curl
+
+############
+# installing ruby
+############
 
 # fix a weird error about apt-utils
-RUN apt-get install -yqq --no-install-recommends apt-utils
+# RUN apt-get install -yqq --no-install-recommends apt-utils
 
 # install ruby and gems
 RUN apt-get install -yqq ruby2.7 rubygems ruby-dev
@@ -22,22 +24,52 @@ RUN apt-get install -yqq ruby2.7 rubygems ruby-dev
 # install bundler
 RUN gem install bundler
 
+############
+# installing dependencies not relating to ruby
+############
+ 
 # this line exists cause tzdata is downloaded and asks for user input
 # we obvi cant have that so this line gets rid of that
-RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata 
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -yqq install tzdata 
 
 # download dependencies
-RUN apt-get install -y -f build-essential cmake make libcairo2-dev libpangox-1.0-dev flex bison libglib2.0-dev libgdk-pixbuf-2.0-dev libxml2-dev 
+RUN apt-get install -yqq build-essential cmake make libcairo2-dev libpangox-1.0-dev flex bison libglib2.0-dev libgdk-pixbuf-2.0-dev libxml2-dev 
 
 # install imagemagick cause it throws a fit otherwise
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -yqq && apt-get install -yqq \
     imagemagick libmagickwand-dev --no-install-recommends
+
+############
+# installing ruby dependencies
+############
 
 # bundler throws a fit because we are root
 # but thats the point of a container
 RUN bundle config --global silence_root_warning 1
+
 # download ruby dependencies
 RUN bundle install
-# 
-# # run the bot
+
+############
+# installing the correct fonts for `~equation`
+############
+ 
+# make fonts directory
+RUN mkdir ~/.fonts
+
+# install mtex2mml fonts that mathematical needs
+RUN  cd ~/.fonts && curl -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cmex10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cmmi10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cmr10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cmsy10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/esint10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/eufm10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/msam10.ttf \
+     -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/msbm10.ttf
+
+############
+# running the bot
+############
+
+# run the bot
 CMD ["ruby", "main.rb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ruby version 2.7.2 using debian buster as base
+FROM ubuntu:21.04
+#FROM ruby:2.7.2-buster
+
+# copy everything into home
+COPY . .
+
+# change permissions of /tmp cause it throws a fit otherwise
+RUN chmod 1777 /tmp
+
+# update repository info cache
+RUN apt-get update -yqq && \
+apt-get install -yqq \
+apt-utils ca-certificates
+
+# fix a weird error about apt-utils
+RUN apt-get install -yqq --no-install-recommends apt-utils
+
+# install ruby and gems
+RUN apt-get install -yqq ruby2.7 rubygems ruby-dev
+
+# install bundler
+RUN gem install bundler
+
+# this line exists cause tzdata is downloaded and asks for user input
+# we obvi cant have that so this line gets rid of that
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata 
+
+# download dependencies
+RUN apt-get install -y -f build-essential cmake make libcairo2-dev libpangox-1.0-dev flex bison libglib2.0-dev libgdk-pixbuf-2.0-dev libxml2-dev 
+
+# install imagemagick cause it throws a fit otherwise
+RUN apt-get update && apt-get install -y \
+    imagemagick libmagickwand-dev --no-install-recommends
+
+# bundler throws a fit because we are root
+# but thats the point of a container
+RUN bundle config --global silence_root_warning 1
+# download ruby dependencies
+RUN bundle install
+# 
+# # run the bot
+CMD ["ruby", "main.rb"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@
 *your milage may vary and might be a nightmare to install if you use it on windows*
 
 
-## Setup
+## Config
+
+you first need to copy `config.example.conf` to `config.conf`
+
+you can do that by doing
+
+``` sh
+cp config.example.conf config.conf
+```
+
+once that is done, you have to replace or change the variables to get it up and running. a bunch of it is self explainitory.
+
+for `features` each flag can be changed to turn on or off features. this is good for testing and for security reasons.
+
+## Setup And Run Without Docker(not reccomended)
 
 ### Dependencies Before Ruby
 
@@ -29,7 +43,7 @@ sudo apt install -y build-essential cmake make libcairo2-dev libpangox-1.0-dev f
 ```
 
 
-### Weird font issue for `~equation`
+### Weird Font Issue For `~equation`
 
 There is this weird font issue that happens sometimes
 
@@ -58,7 +72,7 @@ curl -LO http://mirrors.ctan.org/fonts/cm/ps-type1/bakoma/ttf/cmex10.ttf \
 
 ```
 
-### Dependencies for Ruby
+### Dependencies For Ruby
 
 this part is easier, you just need to install
 
@@ -75,27 +89,53 @@ run while in the <Main> directory
 bundle install
 ```
 
-## Config
-
-you first need to copy `config.example.conf` to `config.conf`
-
-you can do that by doing
-
-``` sh
-cp config.example.conf config.conf
-```
-
-once that is done, you have to replace or change the variables to get it up and running. a bunch of it is self explainitory.
-
-for `features` each flag can be changed to turn on or off features. this is good for testing and for security reasons.
-
-
 ## Run
 to run it just do 
 
 ``` sh
 ruby main.rb
 ```
+
+## Setup And Run With Docker
+
+### Build
+to build just run
+
+``` sh
+docker build -t CssBot .
+```
+
+### Run
+
+you can either run detached(in the background) or not
+
+#### Detached
+``` sh
+docker run -d CssBot
+```
+
+#### Not Detached
+
+``` sh
+docker run CssBot
+```
+
+#### Stop Detached Bot
+
+you first need to find the container id. that can be found by running 
+
+``` sh
+docker ps
+```
+
+under the first column
+
+to kill run 
+
+``` sh
+docker stop <container id>
+```
+
 
 ## Documentation
 
@@ -106,8 +146,6 @@ ruby main.rb
 - CONTRIBUTING.md - things to keep in mind while contributing
 
 ## Todo
-
-* Docker 
 
 * Featurized config based gem file
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ all of these dependencies is for the `~equation` command
 
 to install them you can run(if you use ubuntu) 
 ``` sh
-sudo apt install build-essential make libglib2.0-dev libgdk-pixbuf2.0-0 libxml2 cairo cmake libcogl-pango20 flex bison imagemagick
+sudo apt install -y build-essential cmake make libcairo2-dev libpangox-1.0-dev flex bison libglib2.0-dev libgdk-pixbuf-2.0-dev libxml2-dev imagemagick
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ ruby main.rb
 
 ## Setup And Run With Docker
 
+### Dependencies
+
+* Docker
+
 ### Build
 to build just run
 


### PR DESCRIPTION
### What are you trying to accomplish?
add docker support for running the bot

### How are you accomplishing it?
i originally tried using the `ruby` image on dockerhub but its based off of debian and for whatever reason, i ran into issues building the dependencies for debian.

to fix this i just started from the ubuntu 21.04 base image and installed ruby(and its depends) from scratch. this ended up working great as i got it working.


### Is there anything reviewers should know?
when its built, weird errors will show up about `debconf input methods`, i couldnt find a way to fix this but as it builds and works perfectly, im not sure it matters.

that goes for all the errors, it builds at the end of the day and works perfectly so uhhh well does it matter? who knows. 


- [x] Is it safe to rollback this change if anything goes wrong?
yes just stop using docker as the old way also works perfectly.