### PR TITLE
Feature Request: Google Command (Fixed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@ DISCORD_API_TOKEN=""
 DISCORD_CLIENT_ID=""
 DISCORD_GUILD_ID="" # in "development" mode, this is required to be set
 
+# gcse api creds
+GOOGLE_SEARCH_KEY=""
+GOOGLE_SEARCH_ID=""
+
 # postgres database config
 POSTGRES_PASSWORD=
 POSTGRES_USER=

--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,6 @@ DISCORD_API_TOKEN=""
 DISCORD_CLIENT_ID=""
 DISCORD_GUILD_ID="" # in "development" mode, this is required to be set
 
-# gcse api creds
-GOOGLE_SEARCH_KEY=""
-GOOGLE_SEARCH_ID=""
-
 # postgres database config
 POSTGRES_PASSWORD=
 POSTGRES_USER=

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,3 +28,4 @@ features:
   say: true
   whereis: true
   year: true
+  google: true

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,10 @@ mode: "development" # can either be "development" or "production"
 debug: false # enable debug messages
 image_directory_url: "https://uwindsorcss.github.io/files/dir/images/buildings"
 
+# GSCE Creds
+google_search_key: ""
+google_search_id: ""
+
 year_roles:
   1: ""
   2: ""

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -1,5 +1,6 @@
 import {CommandType} from "../types";
 import {logger} from "@/config";
+import process from "process";
 
 import {
   CacheType,
@@ -35,8 +36,8 @@ const googleModule: CommandType = {
       })
       .setTimestamp();
 
-    const search_key = "insert custom search api token";
-    const search_id = "insert custom search engine id";
+    const search_key = process.env.GOOGLE_SEARCH_KEY;
+    const search_id = process.env.GOOGLE_SEARCH_ID;
     const url = `https://www.googleapis.com/customsearch/v1?key=${search_key}&cx=${search_id}&q=${query}`;
 
     // Interfaces for getting specific entries.
@@ -57,9 +58,9 @@ const googleModule: CommandType = {
     })
       .then(async (response: Response) => {
         if (!response.ok) {
-          logger.info("No response.");
+          logger.info("No response from Google");
           interaction.reply({
-            content: "Unable to return any queries.",
+            content: "Google was unable to return any results.",
             ephemeral: true,
           });
         }
@@ -68,9 +69,14 @@ const googleModule: CommandType = {
       })
       .then((data: Results) => {
         let i: number = 0;
-        data.items.forEach((element: SearchResult) => {
-          links.push(`${++i}. [${element.title}](${element.link})`);
-        });
+
+        if (data.items.length == 0) {
+          links.push("No results.");
+        } else {
+          data.items.forEach((element: SearchResult) => {
+            links.push(`${++i}. [${element.title}](${element.link})`);
+          });
+        }
       });
 
     embed.setDescription(`**Query: ${query}**\n${links.join("\n")}`);

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -71,11 +71,12 @@ const googleModule: CommandType = {
         let i: number = 0;
 
         if (data.items.length == 0) {
-          links.push("No results.");
+          links[0] = "No results.";
         } else {
-          data.items.map((element: SearchResult) => {
-            links.push(`${++i}. [${element.title}](${element.link})`);
-          });
+          links = data.items.map(
+            (element: SearchResult) =>
+              `${++i}. [${element.title}](${element.link})`
+          );
         }
       });
 

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -1,0 +1,86 @@
+import {CommandType} from "../types";
+import {logger} from "@/config";
+
+import {
+  CacheType,
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  Colors,
+} from "discord.js";
+
+const googleModule: CommandType = {
+  data: new SlashCommandBuilder()
+    .setName("google")
+    .setDescription("Google something and return the top 10 results.")
+    .addStringOption((option) =>
+      option
+        .setName("query")
+        .setDescription("What you want to Google.")
+        .setRequired(true)
+    )
+    .addUserOption((option) =>
+      option
+        .setName("to")
+        .setDescription("The user you want to direct this to.")
+    ),
+  execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
+    const query = interaction.options.getString("query");
+    const toWhom = interaction.options.getUser("to");
+    const embed = new EmbedBuilder()
+      .setColor(Colors.Blue)
+      .setAuthor({
+        name: `Requested by ${interaction.user.displayName}`,
+        iconURL: `${interaction.user?.avatarURL()}`,
+      })
+      .setTimestamp();
+
+    const search_key = "insert custom search api token";
+    const search_id = "insert custom search engine id";
+    const url = `https://www.googleapis.com/customsearch/v1?key=${search_key}&cx=${search_id}&q=${query}`;
+
+    // Interfaces for getting specific entries.
+    interface SearchResult {
+      title: string;
+      link: string;
+    }
+
+    interface Results {
+      items: SearchResult[];
+    }
+
+    let links: string[] = [];
+
+    await fetch(url, {
+      method: "GET",
+      headers: {Accept: "*/*"},
+    })
+      .then(async (response: Response) => {
+        if (!response.ok) {
+          logger.info("No response.");
+          interaction.reply({
+            content: "Unable to return any queries.",
+            ephemeral: true,
+          });
+        }
+
+        return (await response.json()) as Results;
+      })
+      .then((data: Results) => {
+        let i: number = 0;
+        data.items.forEach((element: SearchResult) => {
+          links.push(`${++i}. [${element.title}](${element.link})`);
+        });
+      });
+
+    embed.setDescription(`**Query: ${query}**\n${links.join("\n")}`);
+
+    if (!toWhom) {
+      interaction.reply({embeds: [embed]});
+    } else {
+      interaction.reply({content: `${toWhom}`, embeds: [embed]});
+    }
+  },
+};
+
+export {googleModule as command};

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -61,7 +61,10 @@ const googleModule: CommandType = {
 
       const res = await fetch(url, {
         method: "GET",
-        headers: {Accept: "*/*"},
+        headers: {
+          Accept: "*/*",
+          ContentType: "application/json",
+        },
       });
 
       if (!res.ok) {

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -28,6 +28,7 @@ const googleModule: CommandType = {
         .setName("query")
         .setDescription("What you want to Google.")
         .setRequired(true)
+        .setMaxLength(120)
     )
     .addUserOption((option) =>
       option
@@ -35,9 +36,10 @@ const googleModule: CommandType = {
         .setDescription("The user you want to direct this to.")
     ),
   execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
-    const query = interaction.options.getString("query");
-    const toWhom = interaction.options.getUser("to");
+    // Had to include the empty string so I can check the length.
     try {
+      const query = interaction.options.getString("query");
+      const toWhom = interaction.options.getUser("to");
       const embed = new EmbedBuilder()
         .setColor(Colors.Blue)
         .setAuthor({

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -1,6 +1,5 @@
 import {CommandType} from "../types";
-import {logger} from "@/config";
-import process from "process";
+import {logger, Config} from "@/config";
 
 import {
   CacheType,
@@ -36,8 +35,8 @@ const googleModule: CommandType = {
       })
       .setTimestamp();
 
-    const search_key = process.env.GOOGLE_SEARCH_KEY;
-    const search_id = process.env.GOOGLE_SEARCH_ID;
+    const search_key = Config.google_search_key;
+    const search_id = Config.google_search_id;
     const url = `https://www.googleapis.com/customsearch/v1?key=${search_key}&cx=${search_id}&q=${query}`;
 
     // Interfaces for getting specific entries.
@@ -50,7 +49,7 @@ const googleModule: CommandType = {
       items: SearchResult[];
     }
 
-    let links: string[] = [];
+    let response: string = "";
 
     await fetch(url, {
       method: "GET",
@@ -71,16 +70,18 @@ const googleModule: CommandType = {
         let i: number = 0;
 
         if (data.items.length == 0) {
-          links[0] = "No results.";
+          response = "No results.";
         } else {
-          links = data.items.map(
-            (element: SearchResult) =>
-              `${++i}. [${element.title}](${element.link})`
-          );
+          response = data.items
+            .map(
+              (element: SearchResult) =>
+                `${++i}. [${element.title}](${element.link})`
+            )
+            .join("\n");
         }
       });
 
-    embed.setDescription(`**Query: ${query}**\n${links.join("\n")}`);
+    embed.setDescription(`**Query: ${query}**\n${response}`);
 
     if (!toWhom) {
       interaction.reply({embeds: [embed]});

--- a/src/commands/google.ts
+++ b/src/commands/google.ts
@@ -73,7 +73,7 @@ const googleModule: CommandType = {
         if (data.items.length == 0) {
           links.push("No results.");
         } else {
-          data.items.forEach((element: SearchResult) => {
+          data.items.map((element: SearchResult) => {
             links.push(`${++i}. [${element.title}](${element.link})`);
           });
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ interface ConfigType {
   year_roles: {
     [key: string]: string;
   };
+  google_search_key: "";
+  google_search_id: "";
   features: {
     art: boolean;
     equation: boolean;
@@ -31,6 +33,7 @@ interface ConfigType {
     say: boolean;
     whereis: boolean;
     year: boolean;
+    google: boolean;
   };
 }
 


### PR DESCRIPTION
### What are you trying to accomplish?
A way for students to google things whilst engaged in conversation on discord, this is very useful when somebody needs help with a specific programming issue.

### How are you accomplishing it?
By creating a command that displays google search results to Discord.
![image](https://github.com/uwindsorcss/css-discord-bot/assets/36034467/9afb1b85-3818-4255-994e-5126f4f4b447)

### Is there anything reviewers should know?
This is my second pull request for the same feature request, my original pull request had some changes I did not expect to have been made. 

Unlike my last pull request, I put the Google Custom Search API credentials in the command file itself instead of being environment variables.

To generate a key: https://developers.google.com/custom-search/v1/overview#api_key
To configure the search engine: https://programmablesearchengine.google.com/controlpanel/all

It is recommended you enable search the web for better and relevant results

If there is an issue you'd like me to address quickly just contact me on Discord. My discord is .morose.

- [x] Is it safe to rollback this change if anything goes wrong?
Yes, I only added a command, and changed config.example.yaml to enable the google command.