### PR TITLE
add /course details command

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,3 +38,4 @@ features:
   whereis: true
   year: true
   google: true
+  course: true

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -6,6 +6,10 @@ This file contains information about the various features available on our bot.
 
 The `art` command allows users to send pre-created ASCII art. Think of it like a huge sticker.
 
+## Course
+
+The `course details` subcommand fetches and shows the details (name, description, etc.) of a course.
+
 ## Edit
 
 The `edit` command allows staff members to edit the messages sent by the bot using the [`say`](#say) or [`prompt`](#prompt) commands.

--- a/src/commands/course.ts
+++ b/src/commands/course.ts
@@ -1,0 +1,80 @@
+import {logger} from "@/config";
+import {
+  CacheType,
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  SlashCommandStringOption,
+} from "discord.js";
+import {CommandType} from "../types";
+import {handleEmbedResponse} from "@/helpers";
+
+interface CourseDetails {
+  Prerequisites: string[];
+  Corequisites: string[];
+  Antirequisites: string[];
+
+  LabHours: number;
+  LectureHours: number;
+
+  Code: string;
+  Name: string;
+  Description: string;
+
+  Notes: string;
+}
+
+const courseModule: CommandType = {
+  data: new SlashCommandBuilder()
+    .setName("course")
+    .setDescription("Get informtion about a course.")
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("details")
+        .setDescription("Get information about a course.")
+        .addStringOption((option: SlashCommandStringOption) =>
+          option
+            .setName("code")
+            .setDescription("The course code to get information about.")
+            .setRequired(true)
+            .setMaxLength(8)
+            .setMinLength(8)
+        )
+    ),
+  execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
+
+    // default will never be used because of setRequired(true)
+    const code: string = interaction.options.getString("code")?.toUpperCase() || "default";
+
+    if(/[A-Z]{4}[0-9]{4}/.test(code) === false) {
+      return await handleEmbedResponse(interaction, true, {
+        message: "Course code should be in the format of ABCD1234."
+      })
+    }
+
+    const endpoint = "https://boratto.ca/winzard/api/details?search=" + code;
+    const fetched = await fetch(endpoint);
+    if(!fetched.ok) {
+      logger.error(`Failed to fetch course details: ${fetched.status} ${fetched.statusText}`)
+      return await handleEmbedResponse(interaction, true, {
+        message: "Failed to fetch course details."
+      })
+    }
+    const details = await fetched.json() as CourseDetails[];
+
+    for(const detail of details) {
+      if(detail.Code === code) {
+        await interaction.reply(`
+**${code}: ${detail.Name.trim()}**
+> ${detail.Description.trim()}
+        `)
+        return;
+      }
+    }
+    await handleEmbedResponse(interaction, true, {
+      message: "Course not found."
+    })
+    return;
+  }
+}
+
+export {courseModule as command}


### PR DESCRIPTION
### What are you trying to accomplish?
Add a `/course details` command, that... displays course details.

![image](https://github.com/uwindsorcss/css-discord-bot/assets/16675719/0a776ab3-1c99-49ee-9666-bc6f6c2dc976)

### How are you accomplishing it?
I'm using the API from the UWinsite scraper I wrote a while ago.

### Is there anything reviewers should know?
- Because I use my own API here, I'm taking on the responsbility of maintaining the feature. I might have to update it later if I, say, change the API schema somehow.
- A `/course options` command should also be written, to list the available time options for a course.


- [x] Is it safe to rollback this change if anything goes wrong?
