### PR TITLE
feat: Add/Remove Course Notification Roles

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -30,6 +30,7 @@
     "say": true,
     "whereis": true,
     "year": true,
+    "notify": true,
     "google": true,
     "course": true,
     "optin": true,

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -1,0 +1,91 @@
+import {CommandType} from "../types";
+import {logger} from "@/config";
+
+import {
+  CacheType,
+  SlashCommandBuilder,
+  GuildMember,
+  ChatInputCommandInteraction,
+} from "discord.js";
+
+const notifyModule: CommandType = {
+  data: new SlashCommandBuilder()
+    .setName("notify")
+    .setDescription("Get or remove course notifications")
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("add")
+        .setDescription("Get a course notification role.")
+        .addStringOption((option) =>
+          option
+            .setName("course")
+            .setDescription("Course code: e.g. Comp1000")
+            .setMinLength(8)
+            .setMaxLength(8)
+            .setRequired(true)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName("remove")
+        .setDescription("Remove a course notification role")
+        .addStringOption((option) =>
+          option
+            .setName("course")
+            .setDescription("Course code: e.g. Comp1000")
+            .setMinLength(8)
+            .setMaxLength(8)
+            .setRequired(true)
+        )
+    ),
+  execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
+    const subCommand = interaction.options.getSubcommand();
+    const student = interaction.member as GuildMember;
+    const courseCode = interaction.options.getString("course");
+    let courseSubject = courseCode.slice(0, 4);
+
+    // This variable forces the format to be like *Comp*
+    courseSubject =
+      courseSubject.charAt(0).toUpperCase() +
+      courseSubject.toLowerCase().slice(1);
+    const courseNumber = courseCode.slice(4);
+
+    if (subCommand === "add") {
+      try {
+        const courseRole = interaction.guild.roles.cache.find(
+          (role) => role.name === `${courseSubject}-${courseNumber}`
+        );
+        await student.roles.add(courseRole);
+        await interaction.reply({
+          content: `You are now notified for **${courseSubject.toUpperCase()}-${courseNumber}** updates.`,
+          ephemeral: true,
+        });
+      } catch (error: any) {
+        logger.info(`Invalid Role: ${courseSubject}-${courseNumber}`);
+        await interaction.reply({
+          content: "Invalid course code!",
+          ephemeral: true,
+        });
+      }
+    } else {
+      try {
+        const courseRole = interaction.guild.roles.cache.find(
+          (role) => role.name === `${courseSubject}-${courseNumber}`
+        );
+        await student.roles.remove(courseRole);
+        await interaction.reply({
+          content: `You are no longer notified for **${courseSubject.toUpperCase()}-${courseNumber}** updates.`,
+          ephemeral: true,
+        });
+      } catch (error: any) {
+        logger.info(`Invalid Role: ${courseSubject}-${courseNumber}`);
+        await interaction.reply({
+          content: "Invalid course code!",
+          ephemeral: true,
+        });
+      }
+    }
+  },
+};
+
+export {notifyModule as command};

--- a/src/commands/notify.ts
+++ b/src/commands/notify.ts
@@ -50,40 +50,29 @@ const notifyModule: CommandType = {
       courseSubject.toLowerCase().slice(1);
     const courseNumber = courseCode.slice(4);
 
-    if (subCommand === "add") {
-      try {
-        const courseRole = interaction.guild.roles.cache.find(
-          (role) => role.name === `${courseSubject}-${courseNumber}`
-        );
+    try {
+      const courseRole = interaction.guild.roles.cache.find(
+        (role) => role.name === `${courseSubject}-${courseNumber}`
+      );
+      if (subCommand === "add") {
         await student.roles.add(courseRole);
         await interaction.reply({
           content: `You are now notified for **${courseSubject.toUpperCase()}-${courseNumber}** updates.`,
           ephemeral: true,
         });
-      } catch (error: any) {
-        logger.info(`Invalid Role: ${courseSubject}-${courseNumber}`);
-        await interaction.reply({
-          content: "Invalid course code!",
-          ephemeral: true,
-        });
-      }
-    } else {
-      try {
-        const courseRole = interaction.guild.roles.cache.find(
-          (role) => role.name === `${courseSubject}-${courseNumber}`
-        );
+      } else {
         await student.roles.remove(courseRole);
         await interaction.reply({
           content: `You are no longer notified for **${courseSubject.toUpperCase()}-${courseNumber}** updates.`,
           ephemeral: true,
         });
-      } catch (error: any) {
-        logger.info(`Invalid Role: ${courseSubject}-${courseNumber}`);
-        await interaction.reply({
-          content: "Invalid course code!",
-          ephemeral: true,
-        });
       }
+    } catch (error: any) {
+      logger.info(`Invalid Role: ${courseSubject}-${courseNumber}`);
+      await interaction.reply({
+        content: "Invalid course code!",
+        ephemeral: true,
+      });
     }
   },
 };


### PR DESCRIPTION
### What are you trying to accomplish?
Adding the course notification command, sorry it took so long I was busy.

### How are you accomplishing it?
By using commands named `notify add` and `notify remove`. It uses a try catch function to get the roles.
![image](https://github.com/user-attachments/assets/c405bfa2-a752-43f4-9c15-1129a3162352)

### Is there anything reviewers should know?
It may be clunky and you could also implement a list of courses for autofill.


- [x] Is it safe to rollback this change if anything goes wrong?
Yes, only 2 files have been changed, the config-example.json to include the notify command option and the notify command itself.